### PR TITLE
Split Error into EncodeError & DecodeError

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,4 @@
-use crate::{CommandReply, Error};
+use crate::{CommandReply, DecodeError};
 
 /// A streaming decoder for VESC communication protocol.
 ///
@@ -43,7 +43,7 @@ impl<const BUFLEN: usize> Decoder<BUFLEN> {
     ///
     /// The decoder automatically manages buffer space by compacting processed
     /// data and will reset if a single frame exceeds buffer capacity.
-    pub fn feed(&mut self, data: &[u8]) -> Result<usize, Error> {
+    pub fn feed(&mut self, data: &[u8]) -> Result<usize, DecodeError> {
         if data.len() > self.buf.len().saturating_sub(self.wpos) {
             self.buf.copy_within(self.rpos..self.wpos, 0);
             self.wpos = self.wpos.saturating_sub(self.rpos);
@@ -82,7 +82,7 @@ impl<const BUFLEN: usize> core::iter::Iterator for Decoder<BUFLEN> {
                     self.rpos += consumed;
                     return Some(reply);
                 }
-                Err(Error::IncompleteData) => return None,
+                Err(DecodeError::IncompleteData) => return None,
                 _ => (),
             }
             self.rpos += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,7 @@ mod command;
 mod decoder;
 mod packer;
 
-pub use command::{Command, CommandReply, Error, Values, ValuesMask, decode, encode};
+pub use command::{
+    Command, CommandReply, DecodeError, EncodeError, Values, ValuesMask, decode, encode,
+};
 pub use decoder::Decoder;

--- a/src/packer.rs
+++ b/src/packer.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{DecodeError, EncodeError};
 
 /// A utility for structured serialization into a pre-allocated buffer. It's
 /// designed for the VESC communication protocol, which requires big-endian byte
@@ -17,35 +17,35 @@ impl<'a> Packer<'a> {
     }
 
     #[inline]
-    pub fn pack_u32(&mut self, value: u32) -> Result<(), Error> {
+    pub fn pack_u32(&mut self, value: u32) -> Result<(), EncodeError> {
         self.pack(&value.to_be_bytes())
     }
 
     #[inline]
-    pub fn pack_i32(&mut self, value: i32) -> Result<(), Error> {
+    pub fn pack_i32(&mut self, value: i32) -> Result<(), EncodeError> {
         self.pack(&value.to_be_bytes())
     }
 
     #[inline]
-    pub fn pack_u16(&mut self, value: u16) -> Result<(), Error> {
+    pub fn pack_u16(&mut self, value: u16) -> Result<(), EncodeError> {
         self.pack(&value.to_be_bytes())
     }
 
     #[inline]
-    pub fn pack_u8(&mut self, value: u8) -> Result<(), Error> {
+    pub fn pack_u8(&mut self, value: u8) -> Result<(), EncodeError> {
         self.pack(&value.to_be_bytes())
     }
 
     #[inline]
-    pub fn pack_f32(&mut self, value: f32, scale: f32) -> Result<(), Error> {
+    pub fn pack_f32(&mut self, value: f32, scale: f32) -> Result<(), EncodeError> {
         self.pack_i32((value * scale) as i32)
     }
 
     #[inline]
-    fn pack(&mut self, bytes: &[u8]) -> Result<(), Error> {
+    fn pack(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
         let need = bytes.len();
         if self.pos + need > self.buf.len() {
-            return Err(Error::BufferTooSmall);
+            return Err(EncodeError::BufferTooSmall);
         }
         self.buf[self.pos..self.pos + need].copy_from_slice(bytes);
         self.pos += need;
@@ -70,44 +70,44 @@ impl<'a> Unpacker<'a> {
     }
 
     #[inline]
-    pub fn unpack_u32(&mut self) -> Result<u32, Error> {
+    pub fn unpack_u32(&mut self) -> Result<u32, DecodeError> {
         Ok(u32::from_be_bytes(self.consume(4)?.try_into().unwrap()))
     }
 
     #[inline]
-    pub fn unpack_i32(&mut self) -> Result<i32, Error> {
+    pub fn unpack_i32(&mut self) -> Result<i32, DecodeError> {
         Ok(i32::from_be_bytes(self.consume(4)?.try_into().unwrap()))
     }
 
     #[inline]
-    pub fn unpack_u16(&mut self) -> Result<u16, Error> {
+    pub fn unpack_u16(&mut self) -> Result<u16, DecodeError> {
         Ok(u16::from_be_bytes(self.consume(2)?.try_into().unwrap()))
     }
 
     #[inline]
-    pub fn unpack_i16(&mut self) -> Result<i16, Error> {
+    pub fn unpack_i16(&mut self) -> Result<i16, DecodeError> {
         Ok(i16::from_be_bytes(self.consume(2)?.try_into().unwrap()))
     }
 
     #[inline]
-    pub fn unpack_u8(&mut self) -> Result<u8, Error> {
+    pub fn unpack_u8(&mut self) -> Result<u8, DecodeError> {
         Ok(u8::from_be_bytes(self.consume(1)?.try_into().unwrap()))
     }
 
     #[inline]
-    pub fn unpack_f32(&mut self, scale: f32) -> Result<f32, Error> {
+    pub fn unpack_f32(&mut self, scale: f32) -> Result<f32, DecodeError> {
         Ok(self.unpack_i32()? as f32 / scale)
     }
 
     #[inline]
-    pub fn unpack_f16(&mut self, scale: f32) -> Result<f32, Error> {
+    pub fn unpack_f16(&mut self, scale: f32) -> Result<f32, DecodeError> {
         Ok(self.unpack_i16()? as f32 / scale)
     }
 
     #[inline]
-    fn consume(&mut self, amount: usize) -> Result<&[u8], Error> {
+    fn consume(&mut self, amount: usize) -> Result<&[u8], DecodeError> {
         if self.pos + amount > self.buf.len() {
-            return Err(Error::IncompleteData);
+            return Err(DecodeError::IncompleteData);
         }
         self.pos += amount;
         Ok(&self.buf[self.pos - amount..self.pos])

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,6 +1,6 @@
 use googletest::prelude::*;
 
-use vesc::{self, Command, Error, ValuesMask};
+use vesc::{self, Command, EncodeError, ValuesMask};
 
 #[test]
 fn encode_get_values() {
@@ -98,6 +98,6 @@ fn encode_buffer_too_small() {
     for n in 0..10 {
         let mut buf = vec![0u8; n];
         let result = vesc::encode(Command::SetRpm(0), &mut buf);
-        assert_that!(result, err(eq(&Error::BufferTooSmall)));
+        assert_that!(result, err(eq(&EncodeError::BufferTooSmall)));
     }
 }

--- a/tests/command_reply.rs
+++ b/tests/command_reply.rs
@@ -1,6 +1,6 @@
 use googletest::prelude::*;
 
-use vesc::{CommandReply, Error, Values};
+use vesc::{CommandReply, DecodeError, Values};
 
 #[test]
 fn decode_get_values_zero_rpm() {
@@ -196,7 +196,7 @@ fn decode_incomplete_data() {
         2, 23, 50, 0, 2, 161, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 128, 255, 255, 158, 70, 0, 1,
         63, 148, 3,
     ];
-    let expected = &Error::IncompleteData;
+    let expected = &DecodeError::IncompleteData;
 
     for i in 1..input.len() {
         assert_that!(vesc::decode(&input[..i]), err(eq(expected)));
@@ -210,7 +210,7 @@ fn decode_checksum_mismatch() {
         218, 0, 21, 94, 130, 3,
     ];
 
-    let expected = &Error::ChecksumMismatch {
+    let expected = &DecodeError::ChecksumMismatch {
         expected: 24194,
         actual: 20131,
     };
@@ -220,7 +220,7 @@ fn decode_checksum_mismatch() {
 #[test]
 fn decode_unknown_packet() {
     let input = [2, 3, 222, 4, 0, 178, 81, 3];
-    let expected = &Error::UnknownPacket { id: 222 };
+    let expected = &DecodeError::UnknownPacket { id: 222 };
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }
 
@@ -230,7 +230,7 @@ fn decode_invalid_frame_start() {
         7, 23, 50, 0, 2, 161, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 128, 255, 255, 158, 70, 0, 1,
         63, 148, 3,
     ];
-    let expected = &Error::InvalidFrame;
+    let expected = &DecodeError::InvalidFrame;
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }
 
@@ -240,7 +240,7 @@ fn decode_invalid_frame_end() {
         2, 23, 50, 0, 2, 161, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 128, 255, 255, 158, 70, 0, 1,
         63, 148, 2,
     ];
-    let expected = &Error::InvalidFrame;
+    let expected = &DecodeError::InvalidFrame;
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }
 
@@ -252,7 +252,7 @@ fn decode_wrong_payload_len_gt_payload() {
     ];
     input[1] = input[1] + 1;
 
-    let expected = &Error::InvalidFrame;
+    let expected = &DecodeError::InvalidFrame;
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }
 
@@ -264,7 +264,7 @@ fn decode_wrong_payload_len_lt_payload() {
     ];
     input[1] = input[1] - 1;
 
-    let expected = &Error::InvalidFrame;
+    let expected = &DecodeError::InvalidFrame;
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }
 
@@ -275,6 +275,6 @@ fn decode_invalid_frame_end_witch_checksum_mismatch() {
         218, 0, 21, 94, 130, 2,
     ];
 
-    let expected = &Error::InvalidFrame;
+    let expected = &DecodeError::InvalidFrame;
     assert_that!(vesc::decode(&input), err(eq(expected)));
 }


### PR DESCRIPTION
I feel like this is a better design decision since encode and decode errors are unlikely to overlap.