### PR TITLE
replace [] indexing with get/get_mut

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ application that needs to communicate with VESC motor controllers.
 |:----------:|-----------------------------------|--------|
 | `4`        | `GetValues`                       | ✅     |
 | `6`        | `SetCurrent`                      | ✅     |
+| `7`        | `SetCurrentBrake`                 | ✅     |
 | `8`        | `SetRpm`                          | ✅     |
 | `10`       | `SetHandbrake`                    | ✅     |
 | `34`       | `ForwardCan`                      | ✅     |

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,6 +40,7 @@ pub enum DecodeError {
 enum CommandId {
     GetValues = 4,
     SetCurrent = 6,
+    SetCurrentBrake = 7,
     SetRpm = 8,
     SetHandbrake = 10,
     ForwardCan = 34,
@@ -53,6 +54,7 @@ impl TryFrom<u8> for CommandId {
         match value {
             id if id == CommandId::GetValues as u8 => Ok(CommandId::GetValues),
             id if id == CommandId::SetCurrent as u8 => Ok(CommandId::SetCurrent),
+            id if id == CommandId::SetCurrentBrake as u8 => Ok(CommandId::SetCurrentBrake),
             id if id == CommandId::SetRpm as u8 => Ok(CommandId::SetRpm),
             id if id == CommandId::SetHandbrake as u8 => Ok(CommandId::SetHandbrake),
             id if id == CommandId::ForwardCan as u8 => Ok(CommandId::ForwardCan),
@@ -128,6 +130,9 @@ pub enum Command<'a> {
     /// negative values drive reverse.
     SetCurrent(f32),
 
+    /// Set motor braking current in amperes, positive values should be used.
+    SetCurrentBrake(f32),
+
     /// Sets the motor speed in revolutions per minute (RPM). Positive values
     /// drive forward; negative values drive reverse.
     SetRpm(i32),
@@ -157,6 +162,10 @@ impl<'a> Command<'a> {
             }
             Self::SetCurrent(current) => {
                 packer.pack_u8(CommandId::SetCurrent as u8)?;
+                packer.pack_f32(*current, 1000.0)?;
+            }
+            Self::SetCurrentBrake(current) => {
+                packer.pack_u8(CommandId::SetCurrentBrake as u8)?;
                 packer.pack_f32(*current, 1000.0)?;
             }
             Self::SetRpm(rpm) => {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -61,7 +61,10 @@ impl<const BUFLEN: usize> Decoder<BUFLEN> {
         }
 
         let copied = data.len().min(self.buf.len().saturating_sub(self.wpos));
-        self.buf[self.wpos..self.wpos + copied].copy_from_slice(&data[..copied]);
+        self.buf
+            .get_mut(self.wpos..self.wpos + copied)
+            .ok_or(DecodeError::Internal)?
+            .copy_from_slice(data.get(..copied).ok_or(DecodeError::Internal)?);
         self.wpos += copied;
         Ok(copied)
     }


### PR DESCRIPTION
Replace `[]` indexing with `get/get_mut`, I've not replaced it in the `Decoder` `Iterator` implementation because there would be no way of distinguishing an internal error from simply needing more data.